### PR TITLE
bugfix output on detected formats.

### DIFF
--- a/cmd/dat/root.go
+++ b/cmd/dat/root.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Setheck/dat/pkg/build"
-	"github.com/Setheck/dat/pkg/clipper"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"github.com/Setheck/dat/pkg/build"
+	"github.com/Setheck/dat/pkg/clipper"
 )
 
 const DateFormat = "01/02/2006 15:04:05 -0700"
@@ -73,6 +74,8 @@ type options struct {
 	Delta        string
 	Zone         string
 	Tf           bool
+
+	detectedFormat string
 }
 
 // NewRootCommand creates a new instance of a RootCommand
@@ -186,11 +189,10 @@ func RunE(opts options, args []string) (err error) {
 			return err
 		}
 		if name, ok := supportedTimeFormats[format]; ok {
-			fmt.Println("detected format:", name)
+			opts.detectedFormat = name
 		} else {
 			fmt.Println("failed to detect format.")
 		}
-		return nil
 	} else {
 		// validate and convert to time
 		tm, err = ParseEpochTime(epochstr, opts.Milliseconds)
@@ -241,6 +243,9 @@ func BuildOutput(tm time.Time, opts options) string {
 
 	switch {
 	case opts.All:
+		if opts.detectedFormat != "" {
+			output += fmt.Sprintln("detected:", opts.detectedFormat)
+		}
 		output += fmt.Sprintln("epoch:", intTime)
 		fallthrough
 	case opts.Local && opts.UTC:

--- a/cmd/dat/root_test.go
+++ b/cmd/dat/root_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Setheck/dat/pkg/clipper"
-	"github.com/Setheck/dat/pkg/mocks"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/Setheck/dat/pkg/clipper"
+	"github.com/Setheck/dat/pkg/mocks"
 )
 
 const (
@@ -360,6 +361,8 @@ func TestRootCommand_BuildOutput(t *testing.T) {
 			fmt.Sprintf("local: %s\n zone: %s\n", tm.Local().Format(DateFormat), tm.In(laZone).Format(DateFormat))},
 		{"utc and local", tm, options{Local: true, UTC: true},
 			fmt.Sprintf("local: %s\n  utc: %s\n", tm.Local().Format(DateFormat), tm.UTC().Format(DateFormat))},
+		{"all with detection", tm, options{All: true, detectedFormat: "rfc3339"},
+			fmt.Sprintf("detected: %s\nepoch: %d\nlocal: %s\n  utc: %s\n", "rfc3339", tm.Unix(), tm.Local().Format(DateFormat), tm.UTC().Format(DateFormat))},
 		{"all", tm, options{All: true},
 			fmt.Sprintf("epoch: %d\nlocal: %s\n  utc: %s\n", tm.Unix(), tm.Local().Format(DateFormat), tm.UTC().Format(DateFormat))},
 		{"all with zone", tm, options{All: true, Zone: tzLosAngeles},


### PR DESCRIPTION
* format detection now flows through appropriate output formatting. If format detection is used along with the all `-a` flag, the detection information is included.